### PR TITLE
Syntax fix

### DIFF
--- a/check_debian_updates/check_debian_updates
+++ b/check_debian_updates/check_debian_updates
@@ -77,6 +77,7 @@ do
     c ) CRIT_THRESH=$OPTARG ;;
     v ) VERBOSE=1           ;;
     h ) usage               ;;
+    * ) usage               ;;
   esac
 done
 


### PR DESCRIPTION
Newer bash shells complain if the brace isn't on it's own line so move it to keep them happy.